### PR TITLE
React editor compatibility

### DIFF
--- a/lib/controllers/blameViewController.js
+++ b/lib/controllers/blameViewController.js
@@ -4,6 +4,8 @@ const BlameListView = require('../views/blame-list-view');
 const errorController = require('../controllers/errorController');
 
 const TOGGLE_DEBOUNCE_TIME = 600;
+const SELECTOR_REACT = '.editor-contents > .gutter';
+const SELECTOR = '.gutter';
 
 /**
  * Getter for the currently focused editor.
@@ -85,8 +87,7 @@ function insertBlameView(blameData, focusedEditor) {
   });
 
   // insert the BlameListView after the gutter div
-  var selector = focusedEditor.hasClass('react') ? '.editor-contents > .gutter'
-                                                 : '.gutter';
+  var selector = focusedEditor.hasClass('react') ? SELECTOR_REACT : SELECTOR;
   focusedEditor.find(selector).after(blameView);
   focusedEditor.addClass('blaming');
 


### PR DESCRIPTION
Fixes #11.

Test Plan:
Opened blame in both React and non-React editors, and blame appeared fine.
Also scrolled.
