### PR TITLE
Remove special casing for duplicate gutter class

### DIFF
--- a/lib/controllers/blameViewController.js
+++ b/lib/controllers/blameViewController.js
@@ -4,8 +4,6 @@ const BlameListView = require('../views/blame-list-view');
 const errorController = require('../controllers/errorController');
 
 const TOGGLE_DEBOUNCE_TIME = 600;
-const SELECTOR_REACT = '.editor-contents > .gutter';
-const SELECTOR = '.gutter';
 
 /**
  * Getter for the currently focused editor.
@@ -87,8 +85,7 @@ function insertBlameView(blameData, focusedEditor) {
   });
 
   // insert the BlameListView after the gutter div
-  var selector = focusedEditor.hasClass('react') ? SELECTOR_REACT : SELECTOR;
-  focusedEditor.find(selector).after(blameView);
+  focusedEditor.find('.gutter').after(blameView);
   focusedEditor.addClass('blaming');
 
   // match scroll positions in case we blame at a scrolled position


### PR DESCRIPTION
Atom removed the duplicate gutter class in ba21f0b0d8677583b33baa00d8282b3,
so there's no need to special case things any more.

Test Plan:
Opened git-blame in 0.117.0 and it worked
