### PR TITLE
Actually unmount when toggled

### DIFF
--- a/lib/controllers/blameViewController.js
+++ b/lib/controllers/blameViewController.js
@@ -30,7 +30,7 @@ function toggleBlame(filePath, projectBlamer) {
     // we're already blaming this container, so unmount
     focusedEditor.blaming = false;
     var mountPoint = focusedEditor.find('.git-blame-mount');
-    React.unmountComponentAtNode(mountPoint);
+    React.unmountComponentAtNode(mountPoint[0]);
     mountPoint.remove();
   } else {
     // blame the given file + show view on success


### PR DESCRIPTION
This should help out #21.

React silently accepting a parameter of the wrong type turned out to be a bug:
https://github.com/facebook/react/issues/2079

Test Plan:
Added logging to `componentWillUnmount` and saw it work.
