### PR TITLE
Make loading date value formatted consistent with user preference

### DIFF
--- a/lib/util/blameFormatter.js
+++ b/lib/util/blameFormatter.js
@@ -23,6 +23,15 @@ function parseCommitter(line) {
 }
 
 /**
+ * Formats a date according to the user's preferred format string.
+ * @param {object} date - a moment date object
+ */
+function formatDate(date) {
+  var formatString = atom.config.get('git-blame.dateFormatString');
+  return date.format(formatString);
+}
+
+/**
  * Parses the commit date from blame data for a line of code.
  *
  * @param {string} line - the blame data for a particular line of code
@@ -32,8 +41,7 @@ function parseDate(line) {
   var dateMatcher = /^committer-time\s(.*)$/m;
   var dateStamp = line.match(dateMatcher)[1];
 
-  var formatString = atom.config.get('git-blame.dateFormatString');
-  return moment.unix(dateStamp).format(formatString);
+  return formatDate(moment.unix(dateStamp));
 }
 
 /**
@@ -103,5 +111,6 @@ function parseBlameOutput(blameOut) {
 
 // EXPORTS
 module.exports = {
-  parseBlame: parseBlameOutput
+  parseBlame: parseBlameOutput,
+  formatDate: formatDate
 };

--- a/lib/views/blame-line-view.coffee
+++ b/lib/views/blame-line-view.coffee
@@ -1,15 +1,18 @@
 {$, React, Reactionary} = require 'atom'
-RP = React.PropTypes
 {div, span, a} = Reactionary
+RP = React.PropTypes
+moment = require 'moment'
+{formatDate} = require '../util/blameFormatter'
 
 HASH_LENGTH = 7  # github uses this length
 BLANK_HASH = '-'.repeat(HASH_LENGTH)
+DEFAULT_DATE = formatDate moment("2000-01-01T13:17:00 Z")
 
 
 renderLoading = ->
   div className: 'blame-line loading',
     span className: 'hash', BLANK_HASH
-    span className: 'date', '1337-01-01'
+    span className: 'date', DEFAULT_DATE
     span className: 'committer', 'Loading'
 
 


### PR DESCRIPTION
I noticed in one of your gifs that the date format string wasn't being applied
to the fake date used while blame is loading.

Test Plan:
Changed my date format string, then opened blame on a big file with a
complicated history.
