### PR TITLE
Fix deprecated method

### DIFF
--- a/lib/controllers/blameViewController.js
+++ b/lib/controllers/blameViewController.js
@@ -19,7 +19,7 @@ function toggleBlame(projectBlamer) {
   var filePath = editor.getPath();
 
   if (!editorView.blameView) {
-    var remoteUrl = projectBlamer.repo.getOriginUrl(filePath);
+    var remoteUrl = projectBlamer.repo.getOriginURL(filePath);
     var remoteRevision;
     try {
       remoteRevision = RemoteRevision.create(remoteUrl);


### PR DESCRIPTION
Fixed deprecated method, which caused Atom to crash when running on Ubuntu.