### PR TITLE
fix keymap to open git-blame.

### DIFF
--- a/keymaps/git-blame.json
+++ b/keymaps/git-blame.json
@@ -1,5 +1,5 @@
 {
-  ".editor": {
+  "atom-text-editor": {
     "ctrl-b": "git-blame:toggle"
   }
 }


### PR DESCRIPTION
fix the warning: 
```
Deprecated selectors
git-blame
keymaps/git-blame.json
Use the `atom-text-editor` tag instead of the `editor` class.
```