### PR TITLE
fixes displaying of git blame in the editor's gutter + opening git diffs from remote revision url

### DIFF
--- a/lib/controllers/blameViewController.js
+++ b/lib/controllers/blameViewController.js
@@ -21,7 +21,7 @@ function toggleBlame(projectBlamer) {
   var filePath = editor.getPath();
   if (!filePath) return;
 
-  var editorView = atom.views.getView(editor).spacePenView;
+  var editorView = atom.views.getView(editor);
   if (!editorView.blameView) {
     var remoteUrl = projectBlamer.repo.getOriginURL(filePath);
     var remoteRevision;
@@ -34,7 +34,7 @@ function toggleBlame(projectBlamer) {
 
     // insert the BlameListView after the gutter div
     var mountPoint = $('<div>', {'class': 'git-blame-mount'});
-    editorView.find('.gutter').after(mountPoint);
+    $(editorView.rootElement).find('.gutter').after(mountPoint);
 
     editorView.blameView = React.renderComponent(new BlameListView({
       projectBlamer: projectBlamer,

--- a/lib/views/blame-line-view.coffee
+++ b/lib/views/blame-line-view.coffee
@@ -45,8 +45,7 @@ BlameLineComponent = React.createClass
           a onClick: @didClickHashWithoutUrl, className: 'hash', @props.hash.substring(0, HASH_LENGTH)
         else
           url = @props.remoteRevision.url @props.hash
-          a className: 'hash', href: url,
-            @props.hash.substring(0, HASH_LENGTH)
+          a href: url, target: '_blank', className: 'hash', @props.hash.substring(0, HASH_LENGTH)
         span className: 'date', @props.date
         span className: 'committer text-highlight',
           @props.author.split(' ').slice(-1)[0]

--- a/lib/views/blame-list-view.coffee
+++ b/lib/views/blame-list-view.coffee
@@ -74,7 +74,7 @@ BlameListView = React.createClass
     }
 
   scrollbar: ->
-    @_scrollbar ?= @props.editorView.find('.vertical-scrollbar')
+    @_scrollbar ?= $(@props.editorView.rootElement?.querySelector('.vertical-scrollbar'))
 
   editor: ->
     @_editor ?= @props.editorView.getModel()


### PR DESCRIPTION
Toggling git-blame didn't display the annotations in the editor's gutter, because of issues with selecting the editorView.