### PR TITLE
Expand on '.editor is active' line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-Show git blame for the current editor with the command `ctrl-b`. Only works when `.editor` is active. Submodules? No problem. Click on the revision to be taken to the commit page on Github, Bitbucket, or your remote repository url of choice.
+Show git blame for the current editor with the command `ctrl-b`. Only works when `.editor` is active (cursor is hovering over editor). Submodules? No problem. Click on the revision to be taken to the commit page on Github, Bitbucket, or your remote repository url of choice.
 
 ## Options
 


### PR DESCRIPTION
This really confused me at first and I think it will continue to confuse people. I had to do some digging through issues to find this. It might be a bit of a ugly addition to the docs but saves users of this package the headache of digging through closed issues =D