### PR TITLE
Fix issue #116: destroy line tooltip only when it exists

### DIFF
--- a/lib/views/blame-line-view.coffee
+++ b/lib/views/blame-line-view.coffee
@@ -64,7 +64,8 @@ BlameLineComponent = React.createClass
 
 
   componentWillUnmount: ->
-    $(@getDOMNode()).tooltip "destroy"
+    $el = $(@getDOMNode())
+    $el.tooltip "destroy" if $el.tooltip?
 
   shouldComponentUpdate: ({hash, showOnlyLastNames}) ->
     hash isnt @props.hash or showOnlyLastNames != @props.showOnlyLastNames


### PR DESCRIPTION
Issue #116 STR:
1. Open the blame gutter for a file.
2. Add line and save. An empty gutter line will appear. It has no tooltip.
3. Delete the new line and save. The gutter line component will be destroyed.
4. Attempt to destroy the line tooltip, but it doesn't exist => fail.

Fixed by adding an if.
