### PR TITLE
Add a more reader-friendly label for menu entry

### DIFF
--- a/menus/git-blame.json
+++ b/menus/git-blame.json
@@ -8,7 +8,7 @@
   "menu": [{
     "label": "Packages",
     "submenu": [{
-      "label": "git-blame",
+      "label": "Git Blame",
       "submenu": [{
         "label": "Toggle Git Blame",
         "command": "git-blame:toggle"


### PR DESCRIPTION
This looks rather jarring...

<img src="https://cloud.githubusercontent.com/assets/2346707/15768833/191b5946-2998-11e6-8c8d-72544fed6392.png" width="384" valign="bottom" alt="Figure 1" />

I've amended this package's label (and [that of the other](https://github.com/littlebee/git-time-machine/pull/64)) so it integrates better with every other package's menu-label:

<img src="https://cloud.githubusercontent.com/assets/2346707/15768869/82cb2f74-2998-11e6-93dc-da1e168d4df8.png" width="384" valign="bottom" alt="Figure 2" />