### PR TITLE
Added the ability to hide / show the git commit hash.

### DIFF
--- a/lib/git-blame.js
+++ b/lib/git-blame.js
@@ -69,6 +69,10 @@ module.exports = {
     "showOnlyLastNames": {
       type: 'boolean',
       default: true
+    },
+    "showHash": {
+      type: 'boolean',
+      default: true
     }
   },
 

--- a/lib/views/blame-line-view.coffee
+++ b/lib/views/blame-line-view.coffee
@@ -33,6 +33,7 @@ BlameLineComponent = React.createClass
     backgroundClass: RP.string
     noCommit: RP.bool
     showOnlyLastNames: RP.bool.isRequired
+    showHash: RP.bool.isRequired
 
   render: ->
     if @props.noCommit
@@ -41,18 +42,21 @@ BlameLineComponent = React.createClass
         span className: 'date', @props.date
         span className: 'committer', 'Nobody'
     else
+      labels = []
+      if (@props.showHash)
+        labels.push @props.hash.substring(0, HASH_LENGTH)
+      labels.push @props.date
+      if @props.showOnlyLastNames
+        labels.push @props.author.split(' ').slice(-1)[0]
+      else
+        labels.push @props.author
+      linkText = labels.join ' '
       div className: 'blame-line ' + @props.backgroundClass,
         unless @props.remoteRevision
-          a onClick: @didClickHashWithoutUrl, className: 'hash', @props.hash.substring(0, HASH_LENGTH)
+          a onClick: @didClickHashWithoutUrl, linkText
         else
           url = @props.remoteRevision.url @props.hash
-          a href: url, target: '_blank', className: 'hash', @props.hash.substring(0, HASH_LENGTH)
-        span className: 'date', @props.date
-        span className: 'committer text-highlight',
-          if @props.showOnlyLastNames
-            @props.author.split(' ').slice(-1)[0]
-          else
-            @props.author
+          a href: url, target: '_blank', linkText
 
   componentDidMount: ->
     $el = $(@getDOMNode())
@@ -66,8 +70,8 @@ BlameLineComponent = React.createClass
   componentWillUnmount: ->
     $(@getDOMNode()).tooltip "destroy"
 
-  shouldComponentUpdate: ({hash, showOnlyLastNames}) ->
-    hash isnt @props.hash or showOnlyLastNames != @props.showOnlyLastNames
+  shouldComponentUpdate: ({hash, showOnlyLastNames, showHash}) ->
+    hash isnt @props.hash or showOnlyLastNames != @props.showOnlyLastNames or showHash != @props.showHash
 
   didClickHashWithoutUrl: (event, element) ->
     errorController.showError 'error-no-custom-url-specified'

--- a/lib/views/blame-list-view.coffee
+++ b/lib/views/blame-list-view.coffee
@@ -15,6 +15,7 @@ BlameListLinesComponent = React.createClass
     initialLineCount: RP.number.isRequired
     remoteRevision: RP.object.isRequired
     showOnlyLastNames: RP.bool.isRequired
+    showHash: RP.bool.isRequired
 
   renderLoading: ->
     lines = [0...@props.initialLineCount].map renderLoading
@@ -46,6 +47,8 @@ BlameListLinesComponent = React.createClass
       l.remoteRevision = @props.remoteRevision
       # pass down showOnlyLastNames
       l.showOnlyLastNames = @props.showOnlyLastNames
+      # pass down showHash
+      l.showHash = @props.showHash
 
     @_addAlternatingBackgroundColor lines
     div null, lines.map BlameLineComponent
@@ -56,10 +59,10 @@ BlameListLinesComponent = React.createClass
     else
       @renderLoaded()
 
-  shouldComponentUpdate: ({loading, dirty, showOnlyLastNames}) ->
+  shouldComponentUpdate: ({loading, dirty, showOnlyLastNames, showHash}) ->
     finishedInitialLoad = @props.loading and not loading and not @props.dirty
     finishedEdit = @props.dirty and not dirty
-    showOnlyLastNamesChanged = @props.showOnlyLastNames != showOnlyLastNames
+    showOnlyLastNamesChanged = @props.showOnlyLastNames != showOnlyLastNames or @props.showHash != showHash
     finishedInitialLoad or finishedEdit or showOnlyLastNamesChanged
 
 BlameListView = React.createClass
@@ -78,6 +81,7 @@ BlameListView = React.createClass
       visible: true
       dirty: false
       showOnlyLastNames: atom.config.get('git-blame.showOnlyLastNames')
+      showHash: atom.config.get('git-blame.showHash')
     }
 
   scrollbar: ->
@@ -104,6 +108,7 @@ BlameListView = React.createClass
             initialLineCount: @editor().getLineCount()
             remoteRevision: @props.remoteRevision
             showOnlyLastNames: @state.showOnlyLastNames
+            showHash: @state.showHash
     div
       className: 'git-blame'
       style: width: @state.width, display: display
@@ -163,12 +168,16 @@ BlameListView = React.createClass
     # Keep showOnlyLastNames in sync
     @showOnlyLastNamesObserver = atom.config.observe 'git-blame.showOnlyLastNames', (value) =>
       @setState showOnlyLastNames: value
+    # Keep showHash in sync
+    @showHashObserver = atom.config.observe 'git-blame.showHash', (value) =>
+      @setState showHash: value
 
   componentWillUnmount: ->
     @scrollbar().off 'scroll', @matchScrollPosition
     @editor().off 'contents-modified', @contentsModified
     @editor().buffer.off 'saved', @saved
     @showOnlyLastNamesObserver.dispose()
+    @showHashObserver.dispose()
 
   # Makes the view arguments scroll position match the target elements scroll
   # position

--- a/styles/git-blame.less
+++ b/styles/git-blame.less
@@ -43,12 +43,9 @@ atom-text-editor .git-blame-mount {
             background-color: darken(@git-blame-bg-color, 4%);
           }
 
-          .hash, .date {
+          a {
             font-size: 90%;
             padding-right: @component-padding;
-          }
-
-          a.hash {
             color: @text-color;
             text-decoration: none;
           }


### PR DESCRIPTION
Made the blame line contents all one big link and added an option to not show the git commit.

This is for [https://github.com/alexcorre/git-blame/issues/137] - Option to hide hash

