### PR TITLE
Removing Shadow DOM reverence that were deprecated in atom v1.13.0

### DIFF
--- a/styles/git-blame.less
+++ b/styles/git-blame.less
@@ -7,7 +7,6 @@
 
 @git-blame-bg-color: @base-background-color;
 
-atom-text-editor::shadow .git-blame-mount,
 atom-text-editor .git-blame-mount {
   position: relative;
 


### PR DESCRIPTION
Removing Shadow DOM references that were deprecated in atom v1.13.0 to fix issue #156.