### PR TITLE
Replace shadow DOM reference with translated selector

### DIFF
--- a/styles/git-blame.less
+++ b/styles/git-blame.less
@@ -7,7 +7,7 @@
 
 @git-blame-bg-color: @base-background-color;
 
-atom-text-editor::shadow .git-blame-mount,
+atom-text-editor.editor .git-blame-mount,
 atom-text-editor .git-blame-mount {
   position: relative;
 


### PR DESCRIPTION
This fixes the deprecation issue raised in https://github.com/alexcorre/git-blame/issues/156.