### PR TITLE
Fix for repos with non-known remotes

### DIFF
--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -229,7 +229,7 @@ export default class BlameGutter {
   }
 
   dispose() {
-    gutter().destroy();
+    this.gutter().destroy();
   }
 
 }

--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -101,6 +101,8 @@ export default class BlameGutter {
       .then(([repo, blameData]) => {
         let lastHash = null;
         let className = null;
+        let remoteRevision = new RemoteRevision(repo.getOriginURL(filePath));
+        let hasUrlTemplate = !!remoteRevision.getTemplate();
 
         blameData.forEach(lineData => {
           const { lineNumber, hash, noCommit } = lineData;
@@ -115,7 +117,7 @@ export default class BlameGutter {
           lastHash = lineData.hash;
 
           // generate a link to the commit
-          const viewCommitUrl = RemoteRevision.create(repo.getOriginURL(filePath)).url(lineData.hash);
+          const viewCommitUrl = hasUrlTemplate ? remoteRevision.url(lineData.hash) : '#';
 
           // construct props for BlameLine component
           const lineProps = {


### PR DESCRIPTION
This fixes error in #174 when repo is non-github/bitbucket and no custom url template is set.