### PR TITLE
Added an option to not show the hash in the gutter

### DIFF
--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -21,12 +21,14 @@ export default function BlameLine(props) {
   } = props;
 
   const displayName = showOnlyLastNames ? lastWord(author) : author;
-
+  const showHash = atom.config.get('git-blame.showHash');
   return (
     <div className={'blame-line ' + className}>
-      <a href={viewCommitUrl} className="hash">{hash.substring(0, HASH_LENGTH)}</a>
-      <span className="date">{date}</span>
-      <span className="committer text-highlight">{displayName}</span>
+      <a href={viewCommitUrl}>
+        {showHash ? <span className="hash">{hash.substring(0, HASH_LENGTH)}</span> : null}
+        <span className="date">{date}</span>
+        <span className="committer text-highlight">{displayName}</span>
+      </a>
     </div>
   );
 }

--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -17,11 +17,11 @@ export default function BlameLine(props) {
     date,
     author,
     showOnlyLastNames,
+    showHash,
     viewCommitUrl,
   } = props;
 
   const displayName = showOnlyLastNames ? lastWord(author) : author;
-  const showHash = atom.config.get('git-blame.showHash');
   return (
     <div className={'blame-line ' + className}>
       <a href={viewCommitUrl}>

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,4 +25,8 @@ export default {
     type: 'boolean',
     default: false
   },
+  showHash : {
+    type: 'boolean',
+    default: true
+  },
 }

--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -90,6 +90,7 @@ export default class BlameGutter {
 
   updateLineMarkers(filePath) {
     const showOnlyLastNames = atom.config.get('git-blame.showOnlyLastNames');
+    const showHash = atom.config.get('git-blame.showHash');
     return repositoryForEditorPath(filePath)
       .then(repo => {
         const blamer = new Blamer(repo);
@@ -126,6 +127,7 @@ export default class BlameGutter {
             className,
             viewCommitUrl,
             showOnlyLastNames,
+            showHash,
           };
 
           // adding one marker to the first line


### PR DESCRIPTION
Implementation for #137
* For me the date and name are the important pieces of information.
* It defaults to shown so that the default behaviour is the current behaviour.
* Moved the link to encompass all the fragments of information so that clicking any will open the commit in the browser (both needed for having no hash and useful even when it's still there).

The repro doesn't have instructions for running the unit tests, and so I haven't ran them - it'd be great if there was a CONTRIBUTING.md