### PR TITLE
adds possibility for extra cli params

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,4 +25,8 @@ export default {
     type: 'boolean',
     default: false
   },
+  extraCliParams : {
+    type: 'string',
+    default: ''
+  },
 }

--- a/lib/util/GitCommander.js
+++ b/lib/util/GitCommander.js
@@ -76,6 +76,9 @@ export default class GitCommander {
     }
 
     args.push(fileName);
+    
+    const extraArgs = atom.config.get('git-blame.extraCliParams')
+    args.push(...extraArgs.split(' '))
 
     // Execute blame command and parse
     this.exec(args, function(err, blameStdOut) {


### PR DESCRIPTION
fixes #196 

This made it possible to use git-blame to track down changes over renames with `-C -C`that just showed the move commit otherwise.