### PR TITLE
Adding support for copy sha in clipboard by click on sha if there is no view url

### DIFF
--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -21,10 +21,11 @@ export default function BlameLine(props) {
   } = props;
 
   const displayName = showOnlyLastNames ? lastWord(author) : author;
+  const linkCssClass = 'hash' + (viewCommitUrl == '#' ? ' hash-no-view-url' : '');
 
   return (
     <div className={'blame-line ' + className}>
-      <a href={viewCommitUrl} className="hash">{hash.substring(0, HASH_LENGTH)}</a>
+      <a href={viewCommitUrl} className={linkCssClass}>{hash.substring(0, HASH_LENGTH)}</a>
       <span className="date">{date}</span>
       <span className="committer text-highlight">{displayName}</span>
     </div>

--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -63,6 +63,7 @@ export default class BlameGutter {
       // we are showing the gutter
       this.gutter().show();
       this.updateLineMarkers(filePath);
+      this.bindCopyShaToCliboard();
     } else {
       this.removeLineMarkers();
       this.gutter().hide();
@@ -86,6 +87,19 @@ export default class BlameGutter {
       visible: false,
       priority: 100,
     });
+  }
+
+  bindCopyShaToCliboard(){
+    this.gutter().element.addEventListener('click', function(event){
+      const target = event.target;
+      if (target &&
+        target.tagName == 'A' &&
+        target.classList.contains('hash-no-view-url')
+      ){
+        atom.clipboard.write(target.innerText);
+        atom.notifications.addSuccess('SHA ' + target.innerText + ' copied to clipboard');
+      }
+    }, false);
   }
 
   updateLineMarkers(filePath) {


### PR DESCRIPTION
Few possible scenarios:
* no view url exists
* developer prefers to use terminal to check the content of the commit
* something else maybe

For such cases easy copying of sha by clicking on it in gutter might be useful.

// I did this change for myself, but maybe it will be useful for others. 
// It is my first experience with atom plugins, so any comments are highly appreciated