### PR TITLE
Add GitLab to default repo sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Use `ctrl-b` to activate blame. Alternatively, right click the file you want to 
 Click on the revision hash in the gutter to visit the configured repository diff site. Hosts supported out of the box are:
 
 * [GitHub](https://github.com/)
-* [BitBucket](https://bitbucket.org/)
+* [Bitbucket](https://bitbucket.org/)
+* [GitLab](https://gitlab.com/)
 
 Custom remotes can be set globally via options. See below.
 
@@ -34,7 +35,7 @@ If this option is selected, only the last word of the author's name will be disp
 Default date format is `YYYY-MM-DD`. This feature is backed by [moment.js](http://momentjs.com/). Any formats [supported by moment](http://momentjs.com/docs/#/displaying/format/) are valid here.
 
 ### Custom Remote Repo Url
-This plugin will first check to see if your repo is backed by **Github** or **Bitbucket** so nothing is required if your repo is hosted on one of these.
+This plugin will first check to see if your repo is backed by **GitHub**, **Bitbucket**, or **GitLab** so nothing is required if your repo is hosted on one of these.
 
 If its not, you can easily set a custom revision URL string like so:
 - From the settings view go to settings for this package *Git Blame*

--- a/lib/locales/strings.js
+++ b/lib/locales/strings.js
@@ -8,7 +8,7 @@
    'git-blame-error': 'Git Blame Error:',
 
    // ERROR Messages
-   'error-no-custom-url-specified': 'Woops! It looks like you didn\'t enter a Custom Commit Url Template String in the package settings. Please do so in order to open commit hashes for repos that are not hosted on Github or Bitbucket.',
+   'error-no-custom-url-specified': 'Woops! It looks like you didn\'t enter a Custom Commit Url Template String in the package settings. Please do so in order to open commit hashes for repos that are not hosted on GitHub, Bitbucket, or GitLab.',
    'error-file-path-not-checked-in': 'Looks like this file is not yet checked in, so we can\'t find any blame info to show you.',
    'error-problem-parsing-data-from-remote': 'Looks like we were unable to get the project and repo name from your remote url. It may have a format we haven\'t seen before. Please file an issue!',
    'error-not-backed-by-git': 'We\'ve got nothing to show you. This project doesn\'t appear to be backed by git.'

--- a/lib/util/RemoteRevision.js
+++ b/lib/util/RemoteRevision.js
@@ -36,6 +36,11 @@ _.extend(RemoteRevision.prototype, {
   bitbucketTemplate: 'https://bitbucket.org/<%- project %>/<%- repo %>/commits/<%- revision %>',
 
   /**
+   * Default url template for a gitlab.com commit.
+   */
+  gitlabTemplate: 'https://gitlab.com/<%- project %>/<%- repo %>/commit/<%- revision %>',
+
+  /**
    * Should be called after the remote property is set. Parses the remote url
    * for project and repo and stores them as their own properties.
    */
@@ -109,16 +114,20 @@ _.extend(RemoteRevision.prototype, {
   },
 
   /**
-   * Creates a template function using either default github / bitbucket
+   * Creates a template function using default GitHub / Bitbucket / GitLab
    * url templates or a custom url template strings specified in the configs.
    */
   getTemplate: function() {
-    if (this.isGithub()) {
+    if (this.isGitHub()) {
       return this.safeTemplate(this.githubTemplate);
     }
 
     if (this.isBitbucket()) {
       return this.safeTemplate(this.bitbucketTemplate);
+    }
+
+    if (this.isGitLab()) {
+      return this.safeTemplate(this.gitlabTemplate);
     }
 
     if (atom.config.get('git-blame.useCustomUrlTemplateIfStandardRemotesFail')) {
@@ -134,18 +143,26 @@ _.extend(RemoteRevision.prototype, {
   },
 
   /**
-   * Returns true if this RemoteRevision represents a github repository.
+   * Returns true if this RemoteRevision represents a GitHub repository.
    */
-  isGithub: function() {
+  isGitHub: function() {
     return /github.com/.test(this.remote);
   },
 
   /**
-   * Returns true if this RemoteRevision represents a bitbucket repository.
+   * Returns true if this RemoteRevision represents a Bitbucket repository.
    */
   isBitbucket: function() {
     return /bitbucket.org/.test(this.remote);
   }
+
+  /**
+   * Returns true if this RemoteRevision represents a GitLab repository.
+   */
+  isGitLab: function() {
+    return /gitlab.com/.test(this.remote);
+  }
+
 
 });
 


### PR DESCRIPTION
Add GitLab to the default list of sites supported out of the box.

Also fix the capitalization of GitHub and Bitbucket.

Fix #183