### PR TITLE
if no viewCommitUrl copy hash onClick

### DIFF
--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import strings from '../locales/strings';
+
 const HASH_LENGTH = 7;
 const colours = {};
 
@@ -28,6 +30,27 @@ function stringToColour(str) {
   return colour;
 }
 
+function copyText(str) {
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.style.display = 'none';
+    textarea.textContent = str;
+    document.body.appendChild(textarea);
+    textarea.select();
+    const success = document.execCommand('cut');
+    if (!success) throw new Error('copy unsuccessful');
+    const messageString = strings['copy-success']
+    atom.notifications.addSuccess(messageString, {
+      dismissable: true
+    });
+  } catch(err) {
+    console.error('git-blame: error copying hash');
+    console.error(err);
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
 export default function BlameLine(props) {
   const {
     className,
@@ -39,7 +62,7 @@ export default function BlameLine(props) {
     viewCommitUrl,
     colorCommitAuthors,
   } = props;
-
+  const onClick = viewCommitUrl === '#' ? () => copyText(hash) : null;
   const displayName = showOnlyLastNames ? lastWord(author) : author;
   return (
     <div className={`blame-line ${className}`} style={{ borderRight: colorCommitAuthors ? `2px solid ${stringToColour(author)}` : 'none' }}>

--- a/lib/locales/strings.js
+++ b/lib/locales/strings.js
@@ -7,6 +7,7 @@
 
 export default {
   // Strings
+  'copy-success': 'Commit hash copied to clipboard.',
   'git-blame-error': 'Git Blame Error:',
 
   // ERROR Messages


### PR DESCRIPTION
if git-blame cannot determine the commit url, copy the hash on click.