### PR TITLE
Fix text overflow in gutter

### DIFF
--- a/styles/git-blame.less
+++ b/styles/git-blame.less
@@ -31,6 +31,7 @@ atom-text-editor .gutter[gutter-name="com.alexcorre.git-blame"] {
     overflow: hidden;
     text-overflow: ellipsis;
     text-align: left;
+    white-space: nowrap;
     padding: 0 4px;
 
     &.lighter {


### PR DESCRIPTION
The text was still overflowing onto the next line. This was mostly invisible since the content would wind up under the next annotation, but when a no commit change was near it would be visible. By using `nowrap` the text stays on the same line and the overflow properties behave properly.