### PR TITLE
Add Option to Assign Color for Each Commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ If this option is selected, only the last word of the author's name will be disp
 
 Default date format is `YYYY-MM-DD`. This feature is backed by [moment.js](http://momentjs.com/). Any formats [supported by moment](http://momentjs.com/docs/#/displaying/format/) are valid here.
 
-### Color commit authors
-If this option is selected, the commit authors will appear with a unique color to make them easily recognisable.
+### Color Commit
+If this option is selected, the commit authors or commit will appear with a unique color to make them easily recognisable.
 
 ### Custom Remote Repo Url
 This plugin will first check to see if your repo is backed by **GitHub**, **Bitbucket**, or **GitLab** so nothing is required if your repo is hosted on one of these.

--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -37,12 +37,20 @@ export default function BlameLine(props) {
     showOnlyLastNames,
     showHash,
     viewCommitUrl,
-    colorCommitAuthors,
+    colorCommit,
   } = props;
 
   const displayName = showOnlyLastNames ? lastWord(author) : author;
+  let color;
+  if (colorCommit === 'hash') {
+    color = stringToColour(hash);
+  } else if (colorCommit === 'author') {
+    color = stringToColour(author);
+  } else {
+    color = null;
+  }
   return (
-    <div className={`blame-line ${className}`} style={{ borderRight: colorCommitAuthors ? `2px solid ${stringToColour(author)}` : 'none' }}>
+    <div className={`blame-line ${className}`} style={{ borderRight: color ? `2px solid ${color}` : 'none' }}>
       <a href={viewCommitUrl}>
         {showHash ? <span className="hash">{hash.substring(0, HASH_LENGTH)}</span> : null}
         <span className="date">{date}</span>

--- a/lib/config.js
+++ b/lib/config.js
@@ -29,8 +29,13 @@ export default {
     type: 'boolean',
     default: true,
   },
-  colorCommitAuthors: {
-    type: 'boolean',
-    default: false,
-  },
+  colorCommit: {
+    type: 'string',
+    default: 'NONE',
+    enum: [
+      {value: 'NONE', description: 'No Color'},
+      {value: 'author', description: 'Assign color for each Author'},
+      {value: 'hash', description: 'Assign color for each commit'}
+    ]
+  }
 };

--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -95,6 +95,7 @@ export default class BlameGutter {
     const showOnlyLastNames = atom.config.get('git-blame.showOnlyLastNames');
     const showHash = atom.config.get('git-blame.showHash');
     const colorCommitAuthors = atom.config.get('git-blame.colorCommitAuthors');
+    const colorCommit = atom.config.get('git-blame.colorCommit');
     return repositoryForEditorPath(filePath)
       .then((repo) => {
         const blamer = new Blamer(repo);
@@ -133,6 +134,7 @@ export default class BlameGutter {
             showOnlyLastNames,
             showHash,
             colorCommitAuthors,
+            colorCommit,
           };
 
           // adding one marker to the first line


### PR DESCRIPTION
On v.1.4.0, assigning colors for each author and it's great.
Furthermore, I want to assign colors for each commit.