### PR TITLE
Fix the non-working blame functionality for certain files

### DIFF
--- a/lib/util/Blamer.js
+++ b/lib/util/Blamer.js
@@ -23,7 +23,7 @@ export default class Blamer {
 
     const submodules = this.repo.submodules;
     if (submodules) {
-      each(submodules, (submodulePath) => {
+      each(submodules, (submodule, submodulePath) => {
         this.tools[submodulePath] = new GitCommander(`${this.repo.getWorkingDirectory()}/${submodulePath}`);
       });
     }
@@ -71,7 +71,7 @@ export default class Blamer {
     // belongs inside one of the repositories. If so, we return the GitCommander repo
     // for that submodule.
     if (submodules) {
-      each(submodules, (submodulePath) => {
+      each(submodules, (submodule, submodulePath) => {
         const submoduleRegex = new RegExp(`^${submodulePath}`);
         if (submoduleRegex.test(filePath)) {
           repoUtil = this.tools[submodulePath];
@@ -93,7 +93,7 @@ export default class Blamer {
     let trimmedFilePath = filePath;
     const submodules = this.repo.submodules;
     if (submodules) {
-      each(submodules, (submodulePath) => {
+      each(submodules, (submodule, submodulePath) => {
         const submoduleRegex = new RegExp(`^${submodulePath}`);
         if (submoduleRegex.test(trimmedFilePath)) {
           trimmedFilePath = filePath.replace(submoduleRegex, '');


### PR DESCRIPTION
This should hopefully fix #219 (I'm not sure whether the issue is the same).
Conditions:
* Have at least one submodule in your repository.
* Have a file for which its relative path (relative to the repository) starts with one of the following letters: o, O, b, j, e, c, t.

If these conditions are met, then child_process.spawn fails because an invalid current directory option is passed, which causes nothing to be displayed in the gutter. This issue exists ever since fc4955e29e268ab298ffe5c7601a137d947c9dec.