### PR TITLE
add support for custom gitBinary path

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,10 @@ export default {
     type: 'string',
     default: 'YYYY-MM-DD',
   },
+  gitBinary: {
+    type: 'string',
+    default: 'git',
+  },
   ignoreWhiteSpaceDiffs: {
     type: 'boolean',
     default: false,

--- a/lib/util/GitCommander.js
+++ b/lib/util/GitCommander.js
@@ -28,7 +28,9 @@ export default class GitCommander {
       return;
     }
 
-    const child = childProcess.spawn('git', args, {cwd: this.workingDirectory});
+    const gitBinary = atom.config.get('git-blame.gitBinary');
+
+    const child = childProcess.spawn(gitBinary, args, {cwd: this.workingDirectory});
     let stdout = '';
     let stderr = '';
     let processError;


### PR DESCRIPTION
This commit allows users to specify the path to their `git` binary in a new "Git Binary" package setting. 

The use case that inspired this small addition is working on a machine that has `git` installed, but does not have it in its PATH. There are often cases where a user might not have the permissions to edit their PATH (or they may not want to for some other reason). This PR allows those users to still use the git-blame package by specifying where `git` lives.

The newly added setting:
![the gitBinary setting](https://user-images.githubusercontent.com/14897503/38393016-597872ba-38de-11e8-8c43-a9cfc53ff97e.png)
