### PR TITLE
Added ability to show only first name. If both settings to show first…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ Custom remotes can be set globally via options. See below.
 
 If this option is selected, the `git blame` command will be run with `-w` option.
 
-### Show Only Last Names
+### Show First Names
 
-If this option is selected, only the last word of the author's name will be displayed.
+If this option is selected, only the first word of the author's name will be displayed. (If both Show First Names and Show Last Names are enabled, the entire author name will be displayed, regardless of whether it contains only two name parts).
+
+### Show Last Names
+
+If this option is selected, only the last word of the author's name will be displayed. (If both Show First Names and Show Last Names are enabled, the entire author name will be displayed, regardless of whether it contains only two name parts).
 
 ### Date Format String
 

--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -6,9 +6,9 @@ import strings from '../locales/strings';
 const HASH_LENGTH = 7;
 const colours = {};
 
-function lastWord(str) {
+function word(str, index) {
   const words = str.split(' ');
-  return words[words.length - 1];
+  return words[index < 0 ? words.length + index : index];
 }
 
 function stringToColour(str) {
@@ -49,7 +49,8 @@ export default function BlameLine(props) {
     hash,
     date,
     author,
-    showOnlyLastNames,
+    showFirstNames,
+    showLastNames,
     showHash,
     viewCommitUrl,
     colorCommitAuthors,
@@ -58,7 +59,13 @@ export default function BlameLine(props) {
   const onClick = copyHashOnClick ?
     () => { return copyText(hash); } :
     null;
-  const displayName = showOnlyLastNames ? lastWord(author) : author;
+  const displayName = showFirstNames && showLastNames
+    ? author
+    : showFirstNames
+      ? word(author, 0)
+      : showLastNames
+        ? word(author, -1)
+        : '';
   return (
     <div className={`blame-line ${className}`} style={{ borderRight: colorCommitAuthors ? `2px solid ${stringToColour(author)}` : 'none' }}>
       <a href={viewCommitUrl} onClick={onClick}>

--- a/lib/components/BlameLine.js
+++ b/lib/components/BlameLine.js
@@ -59,13 +59,15 @@ export default function BlameLine(props) {
   const onClick = copyHashOnClick ?
     () => { return copyText(hash); } :
     null;
-  const displayName = showFirstNames && showLastNames
-    ? author
-    : showFirstNames
-      ? word(author, 0)
-      : showLastNames
-        ? word(author, -1)
-        : '';
+  let displayName = '';
+  if (showFirstNames && showLastNames) {
+    displayName = author;
+  } else if (showFirstNames) {
+    displayName = word(author, 0);
+  } else {
+    displayName = word(author, -1);
+  }
+
   return (
     <div className={`blame-line ${className}`} style={{ borderRight: colorCommitAuthors ? `2px solid ${stringToColour(author)}` : 'none' }}>
       <a href={viewCommitUrl} onClick={onClick}>

--- a/lib/components/GutterResize.js
+++ b/lib/components/GutterResize.js
@@ -11,6 +11,7 @@ function GutterResize({children, onMouseDown}) {
       <div
         className="resize"
         onMouseDown={onMouseDown}
+        role="presentation"
       />
     </div>
   );

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,9 +25,13 @@ export default {
     type: 'boolean',
     default: false,
   },
-  showOnlyLastNames: {
+  showFirstNames: {
     type: 'boolean',
-    default: false,
+    default: true,
+  },
+  showLastNames: {
+    type: 'boolean',
+    default: true,
   },
   showHash: {
     type: 'boolean',

--- a/lib/util/BlameGutter.js
+++ b/lib/util/BlameGutter.js
@@ -95,7 +95,8 @@ export default class BlameGutter {
   }
 
   updateLineMarkers(filePath) {
-    const showOnlyLastNames = atom.config.get('git-blame.showOnlyLastNames');
+    const showFirstNames = atom.config.get('git-blame.showFirstNames');
+    const showLastNames = atom.config.get('git-blame.showLastNames');
     const showHash = atom.config.get('git-blame.showHash');
     const colorCommitAuthors = atom.config.get('git-blame.colorCommitAuthors');
     return repositoryForEditorPath(filePath)
@@ -141,7 +142,8 @@ export default class BlameGutter {
             ...lineData,
             className,
             viewCommitUrl,
-            showOnlyLastNames,
+            showFirstNames,
+            showLastNames,
             showHash,
             colorCommitAuthors,
             copyHashOnClick,

--- a/lib/util/Blamer.js
+++ b/lib/util/Blamer.js
@@ -21,7 +21,7 @@ export default class Blamer {
     this.tools = {};
     this.tools.root = new GitCommander(this.repo.getWorkingDirectory());
 
-    const submodules = this.repo.submodules;
+    const {submodules} = this.repo;
     if (submodules) {
       each(submodules, (submodule, submodulePath) => {
         this.tools[submodulePath] = new GitCommander(`${this.repo.getWorkingDirectory()}/${submodulePath}`);
@@ -62,7 +62,7 @@ export default class Blamer {
    * @param {string} filePath - the path to the file in question.
    */
   repoUtilForPath(filePath) {
-    const submodules = this.repo.submodules;
+    const {submodules} = this.repo;
 
     // By default, we return the root GitCommander repository.
     let repoUtil = this.tools.root;
@@ -91,7 +91,7 @@ export default class Blamer {
    */
   removeSubmodulePrefix(filePath) {
     let trimmedFilePath = filePath;
-    const submodules = this.repo.submodules;
+    const {submodules} = this.repo;
     if (submodules) {
       each(submodules, (submodule, submodulePath) => {
         const submoduleRegex = new RegExp(`^${submodulePath}`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-blame",
   "main": "./lib/index",
-  "version": "1.8.0",
+  "version": "1.7.0",
   "description": "Toggle git-blame annotations in the gutter of atom editor.",
   "activationCommands": {
     "atom-text-editor": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-blame",
   "main": "./lib/index",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Toggle git-blame annotations in the gutter of atom editor.",
   "activationCommands": {
     "atom-text-editor": [


### PR DESCRIPTION
**Added setting to show only first name**
If settings to show both first name and last name are enabled (default) the whole author name is displayed (not just first and last names). Note that a name is still displayed if either first or last name are enabled and the commit-author only has one or the other.

Renamed showOnlyLastNames to showLastNames; Added showFirstNames; cleaned up some lint issues.