### PR TITLE
Fix #193: don't fail when there is no remote named origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Click on the revision hash in the gutter to visit the configured repository diff
 * [Bitbucket](https://bitbucket.org/)
 * [GitLab](https://gitlab.com/)
 
+If the remote repo has a URL we don't recognize, or if there is no remote named
+`origin`, the commit hash will be copied to the clipboard.
 Custom remotes can be set globally via options. See below.
 
 ## Options

--- a/lib/util/RemoteRevision.js
+++ b/lib/util/RemoteRevision.js
@@ -17,7 +17,7 @@ function safeTemplate(templateString) {
 export default class RemoteRevision {
 
   constructor(remote, gitConfigRepositoryUrl) {
-    this.remote = remote;
+    this.remote = remote || '';
     this.gitConfigRepositoryUrl = gitConfigRepositoryUrl;
     this.initialize();
   }
@@ -35,7 +35,7 @@ export default class RemoteRevision {
     if (data.project && data.repo) {
       this.project = data.project;
       this.repo = data.repo;
-    } else {
+    } else if (this.remote !== '') {
       // we were unable to parse data from the remote...
       showError('error-problem-parsing-data-from-remote');
     }

--- a/spec/RemoteRevision-spec.js
+++ b/spec/RemoteRevision-spec.js
@@ -30,7 +30,6 @@ describe('RemoteRevision', function () {
       expect(output).toEqual({});
     });
 
-
     it('Should parse a standard github url correctly', function () {
       var githubRemote = 'git@github.com:project/someRepo.git';
       instance.remote = githubRemote;
@@ -149,6 +148,20 @@ describe('RemoteRevision', function () {
         project: 'Mo.Ox',
         repo: 'moox.github.io',
       });
+    });
+
+  });
+
+  describe('repos with no remotes named origin', function () {
+
+    it('Should return an empty object if no remote repo url is passed in', function () {
+
+      // this will be the case when using Atom's repo.getOriginURL() when there
+      // is no remote named origin
+
+      instance = new RemoteRevision(undefined);
+      var output = instance.parseProjectAndRepo();
+      expect(output).toEqual({});
     });
 
   });


### PR DESCRIPTION
This doesn't add support for remotes with names other than `origin`, but it does add a default value when there isn't a remote named `origin` so that we don't freak out while parsing the project & repo names. This should fix #193.

Also minor update to README to document the "copy hash on click" feature.

**Note:** all of the tests in `specs/RemoteRevision-spec.js` are passing, but the `spec/git-blame-spec.coffee` tests are not. From what I can tell, these appear to be outdated tests and I don't think the failures are related to my changes.